### PR TITLE
feat: add tweak detection

### DIFF
--- a/BareMac/BareMac/Models/Tweak.swift
+++ b/BareMac/BareMac/Models/Tweak.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct Tweak: Identifiable {
+    let id = UUID()
+    let name: String
+    let command: String
+    let revertCommand: String
+    let category: TweakCategory
+    let detectCommand: String?
+    
+    init(name: String,
+         command: String,
+         revertCommand: String,
+         category: TweakCategory,
+         detectCommand: String? = nil) {
+        self.name = name
+        self.command = command
+        self.revertCommand = revertCommand
+        self.category = category
+        self.detectCommand = detectCommand
+    }
+}

--- a/BareMac/BareMac/Models/TweakCategory.swift
+++ b/BareMac/BareMac/Models/TweakCategory.swift
@@ -1,13 +1,3 @@
-import Foundation
-
 enum TweakCategory: String, CaseIterable {
     case system = "System"
-}
-
-struct Tweak: Identifiable {
-    let id = UUID()
-    let name: String
-    let command: String
-    let revertCommand: String
-    let category: TweakCategory
 }

--- a/BareMac/BareMac/Models/TweaksData.swift
+++ b/BareMac/BareMac/Models/TweaksData.swift
@@ -3,6 +3,12 @@ struct TweaksData {
         .init(name: "Show File Extensions",
               command: "defaults write NSGlobalDomain AppleShowAllExtensions -bool TRUE && killall Finder",
               revertCommand: "defaults write NSGlobalDomain AppleShowAllExtensions -bool FALSE && killall Finder",
-              category: .system)
+              category: .system,
+              detectCommand: "defaults read NSGlobalDomain AppleShowAllExtensions"),
+        .init(name: "Show Hidden Files",
+              command: "defaults write com.apple.finder AppleShowAllFiles -bool TRUE && killall Finder",
+              revertCommand: "defaults write com.apple.finder AppleShowAllFiles -bool FALSE && killall Finder",
+              category: .system,
+              detectCommand: "defaults read com.apple.finder AppleShowAllFiles")
     ]
 }

--- a/BareMac/BareMac/Services/TweakExecutor.swift
+++ b/BareMac/BareMac/Services/TweakExecutor.swift
@@ -4,9 +4,24 @@ enum TweakExecutor {
     static func run(_ cmd: String) async -> Bool {
         await withCheckedContinuation { cont in
             let p = Process()
-            p.launchPath = "/bin/zsh"
+            p.executableURL = URL(fileURLWithPath: "/bin/zsh")
             p.arguments = ["-c", cmd]
             p.terminationHandler = { cont.resume(returning: $0.terminationStatus == 0) }
+            try? p.run()
+        }
+    }
+
+    static func read(_ cmd: String) async -> String? {
+        await withCheckedContinuation { cont in
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/bin/zsh")
+            p.arguments = ["-c", cmd]
+            let pipe = Pipe()
+            p.standardOutput = pipe
+            p.terminationHandler = { _ in
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                cont.resume(returning: String(data: data, encoding: .utf8))
+            }
             try? p.run()
         }
     }

--- a/BareMac/BareMac/ViewModels/TweakViewModel.swift
+++ b/BareMac/BareMac/ViewModels/TweakViewModel.swift
@@ -1,10 +1,6 @@
 import SwiftUI
-import Foundation
 
 @MainActor
 final class TweakViewModel: ObservableObject {
     @Published var tweaks = TweaksData.sample
-    func toggle(_ tweak: Tweak) {
-        Task { _ = await TweakExecutor.run(tweak.command) }
-    }
 }

--- a/BareMac/BareMac/Views/ContentView.swift
+++ b/BareMac/BareMac/Views/ContentView.swift
@@ -1,11 +1,17 @@
 import SwiftUI
-import Foundation
 
 struct ContentView: View {
     @StateObject private var vm = TweakViewModel()
+
     var body: some View {
-        List(vm.tweaks) { tweak in
-            Button(tweak.name) { vm.toggle(tweak) }
+        List {
+            ForEach(TweakCategory.allCases, id: \.self) { category in
+                Section(header: Text(category.rawValue)) {
+                    ForEach(vm.tweaks.filter { $0.category == category }) { tweak in
+                        TweakRow(tweak: tweak)
+                    }
+                }
+            }
         }
         .frame(minWidth: 300, minHeight: 400)
     }

--- a/BareMac/BareMac/Views/TweakRow.swift
+++ b/BareMac/BareMac/Views/TweakRow.swift
@@ -19,13 +19,21 @@ struct TweakRow: View {
     }
 
     private func detectInitialState() {
+        guard let cmd = tweak.detectCommand else { return }
+        Task {
+            if let output = await TweakExecutor.read(cmd)?.trimmingCharacters(in: .whitespacesAndNewlines) {
+                await MainActor.run {
+                    self.isOn = (output == "1" || output.lowercased() == "true")
+                }
+            }
+        }
     }
 
     private func apply(_ enabled: Bool) async {
         let cmd = enabled ? tweak.command : tweak.revertCommand
         let ok = await TweakExecutor.run(cmd)
         if !ok {
-            isOn.toggle()
+            await MainActor.run { isOn.toggle() }
             print("[TweakRow] Command failed")
         }
     }


### PR DESCRIPTION
## Summary
- separate `Tweak` model and add optional `detectCommand` for reading current system state
- add `read` helper to `TweakExecutor` and switch to `executableURL`
- use `detectCommand` in `TweakRow` to set initial toggle state
- show tweaks grouped by category with toggle-based UI and extra sample tweak

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swiftc -typecheck BareMac/BareMac/Models/Tweak.swift BareMac/BareMac/Models/TweakCategory.swift BareMac/BareMac/Models/TweaksData.swift BareMac/BareMac/Services/TweakExecutor.swift`


------
https://chatgpt.com/codex/tasks/task_e_6893db02d7d48328b18c7030edde0d48