### PR TITLE
Add helper-based tweak system for rewrite MVP

### DIFF
--- a/BareMac/BareMac/Models/Tweak.swift
+++ b/BareMac/BareMac/Models/Tweak.swift
@@ -3,20 +3,17 @@ import Foundation
 struct Tweak: Identifiable {
     let id = UUID()
     let name: String
-    let command: String
-    let revertCommand: String
     let category: TweakCategory
-    let detectCommand: String?
-    
+    let detect: (() async -> Bool)?
+    let setState: (Bool) async -> Bool
+
     init(name: String,
-         command: String,
-         revertCommand: String,
          category: TweakCategory,
-         detectCommand: String? = nil) {
+         detect: (() async -> Bool)? = nil,
+         setState: @escaping (Bool) async -> Bool) {
         self.name = name
-        self.command = command
-        self.revertCommand = revertCommand
         self.category = category
-        self.detectCommand = detectCommand
+        self.detect = detect
+        self.setState = setState
     }
 }

--- a/BareMac/BareMac/Models/TweakCategory.swift
+++ b/BareMac/BareMac/Models/TweakCategory.swift
@@ -1,5 +1,9 @@
 import Foundation
 
 enum TweakCategory: String, CaseIterable {
+    case finder = "Finder"
+    case dock = "Dock"
+    case safari = "Safari"
+    case screenshots = "Screenshots"
     case system = "System"
 }

--- a/BareMac/BareMac/Models/TweaksData.swift
+++ b/BareMac/BareMac/Models/TweaksData.swift
@@ -1,9 +1,222 @@
+import Foundation
+
 struct TweaksData {
     static let sample: [Tweak] = [
-        .init(name: "Show File Extensions",
-              command: "defaults write NSGlobalDomain AppleShowAllExtensions -bool TRUE && killall Finder",
-              revertCommand: "defaults write NSGlobalDomain AppleShowAllExtensions -bool FALSE && killall Finder",
-              category: .system,
-              detectCommand: "defaults read NSGlobalDomain AppleShowAllExtensions")
+        // Finder
+        .init(
+            name: "Show File Extensions",
+            category: .finder,
+            detect: {
+                DefaultsHelper.getBool(domain: "NSGlobalDomain", key: "AppleShowAllExtensions")
+            },
+            setState: { value in
+                let ok = DefaultsHelper.setBool(value, domain: "NSGlobalDomain", key: "AppleShowAllExtensions")
+                if ok { _ = await TweakExecutor.run("killall Finder") }
+                return ok
+            }
+        ),
+        .init(
+            name: "Show Hidden Files",
+            category: .finder,
+            detect: {
+                DefaultsHelper.getBool(domain: "com.apple.finder", key: "AppleShowAllFiles")
+            },
+            setState: { value in
+                let ok = DefaultsHelper.setBool(value, domain: "com.apple.finder", key: "AppleShowAllFiles")
+                if ok { _ = await TweakExecutor.run("killall Finder") }
+                return ok
+            }
+        ),
+        .init(
+            name: "Show Path Bar",
+            category: .finder,
+            detect: {
+                DefaultsHelper.getBool(domain: "com.apple.finder", key: "ShowPathbar")
+            },
+            setState: { value in
+                let ok = DefaultsHelper.setBool(value, domain: "com.apple.finder", key: "ShowPathbar")
+                if ok { _ = await TweakExecutor.run("killall Finder") }
+                return ok
+            }
+        ),
+        .init(
+            name: "Show Status Bar",
+            category: .finder,
+            detect: {
+                DefaultsHelper.getBool(domain: "com.apple.finder", key: "ShowStatusBar")
+            },
+            setState: { value in
+                let ok = DefaultsHelper.setBool(value, domain: "com.apple.finder", key: "ShowStatusBar")
+                if ok { _ = await TweakExecutor.run("killall Finder") }
+                return ok
+            }
+        ),
+        .init(
+            name: "Show Full Path in Title",
+            category: .finder,
+            detect: {
+                DefaultsHelper.getBool(domain: "com.apple.finder", key: "_FXShowPosixPathInTitle")
+            },
+            setState: { value in
+                let ok = DefaultsHelper.setBool(value, domain: "com.apple.finder", key: "_FXShowPosixPathInTitle")
+                if ok { _ = await TweakExecutor.run("killall Finder") }
+                return ok
+            }
+        ),
+        .init(
+            name: "Warn Before Emptying Trash",
+            category: .finder,
+            detect: {
+                DefaultsHelper.getBool(domain: "com.apple.finder", key: "WarnOnEmptyTrash")
+            },
+            setState: { value in
+                let ok = DefaultsHelper.setBool(value, domain: "com.apple.finder", key: "WarnOnEmptyTrash")
+                if ok { _ = await TweakExecutor.run("killall Finder") }
+                return ok
+            }
+        ),
+        .init(
+            name: "Expand Save Panel by Default",
+            category: .finder,
+            detect: {
+                DefaultsHelper.getBool(domain: "NSGlobalDomain", key: "NSNavPanelExpandedStateForSaveMode")
+            },
+            setState: { value in
+                DefaultsHelper.setBool(value, domain: "NSGlobalDomain", key: "NSNavPanelExpandedStateForSaveMode")
+            }
+        ),
+        .init(
+            name: "Expand Print Panel by Default",
+            category: .finder,
+            detect: {
+                DefaultsHelper.getBool(domain: "NSGlobalDomain", key: "PMPrintingExpandedStateForPrint")
+            },
+            setState: { value in
+                DefaultsHelper.setBool(value, domain: "NSGlobalDomain", key: "PMPrintingExpandedStateForPrint")
+            }
+        ),
+        // Dock
+        .init(
+            name: "Auto-hide Dock",
+            category: .dock,
+            detect: {
+                DefaultsHelper.getBool(domain: "com.apple.dock", key: "autohide")
+            },
+            setState: { value in
+                let ok = DefaultsHelper.setBool(value, domain: "com.apple.dock", key: "autohide")
+                if ok { _ = await TweakExecutor.run("killall Dock") }
+                return ok
+            }
+        ),
+        .init(
+            name: "Enable Dock Magnification",
+            category: .dock,
+            detect: {
+                DefaultsHelper.getBool(domain: "com.apple.dock", key: "magnification")
+            },
+            setState: { value in
+                let ok = DefaultsHelper.setBool(value, domain: "com.apple.dock", key: "magnification")
+                if ok { _ = await TweakExecutor.run("killall Dock") }
+                return ok
+            }
+        ),
+        .init(
+            name: "Minimize into App Icon",
+            category: .dock,
+            detect: {
+                DefaultsHelper.getBool(domain: "com.apple.dock", key: "minimize-to-application")
+            },
+            setState: { value in
+                let ok = DefaultsHelper.setBool(value, domain: "com.apple.dock", key: "minimize-to-application")
+                if ok { _ = await TweakExecutor.run("killall Dock") }
+                return ok
+            }
+        ),
+        .init(
+            name: "Show Indicator Lights",
+            category: .dock,
+            detect: {
+                DefaultsHelper.getBool(domain: "com.apple.dock", key: "show-process-indicators")
+            },
+            setState: { value in
+                let ok = DefaultsHelper.setBool(value, domain: "com.apple.dock", key: "show-process-indicators")
+                if ok { _ = await TweakExecutor.run("killall Dock") }
+                return ok
+            }
+        ),
+        .init(
+            name: "Show Recent Applications",
+            category: .dock,
+            detect: {
+                DefaultsHelper.getBool(domain: "com.apple.dock", key: "show-recents")
+            },
+            setState: { value in
+                let ok = DefaultsHelper.setBool(value, domain: "com.apple.dock", key: "show-recents")
+                if ok { _ = await TweakExecutor.run("killall Dock") }
+                return ok
+            }
+        ),
+        .init(
+            name: "Automatically Rearrange Spaces",
+            category: .dock,
+            detect: {
+                DefaultsHelper.getBool(domain: "com.apple.dock", key: "mru-spaces")
+            },
+            setState: { value in
+                let ok = DefaultsHelper.setBool(value, domain: "com.apple.dock", key: "mru-spaces")
+                if ok { _ = await TweakExecutor.run("killall Dock") }
+                return ok
+            }
+        ),
+        // Screenshots
+        .init(
+            name: "Show Screenshot Thumbnail",
+            category: .screenshots,
+            detect: {
+                DefaultsHelper.getBool(domain: "com.apple.screencapture", key: "show-thumbnail")
+            },
+            setState: { value in
+                let ok = DefaultsHelper.setBool(value, domain: "com.apple.screencapture", key: "show-thumbnail")
+                if ok { _ = await TweakExecutor.run("killall SystemUIServer") }
+                return ok
+            }
+        ),
+        .init(
+            name: "Play Screenshot Sound",
+            category: .screenshots,
+            detect: {
+                !DefaultsHelper.getBool(domain: "com.apple.screencapture", key: "disable-audio")
+            },
+            setState: { value in
+                let ok = DefaultsHelper.setBool(!value, domain: "com.apple.screencapture", key: "disable-audio")
+                if ok { _ = await TweakExecutor.run("killall SystemUIServer") }
+                return ok
+            }
+        ),
+        // Safari
+        .init(
+            name: "Show Develop Menu",
+            category: .safari,
+            detect: {
+                DefaultsHelper.getBool(domain: "com.apple.Safari", key: "IncludeDevelopMenu")
+            },
+            setState: { value in
+                let ok = DefaultsHelper.setBool(value, domain: "com.apple.Safari", key: "IncludeDevelopMenu")
+                if ok { _ = await TweakExecutor.run("killall Safari") }
+                return ok
+            }
+        ),
+        .init(
+            name: "Show Full URL in Address Bar",
+            category: .safari,
+            detect: {
+                DefaultsHelper.getBool(domain: "com.apple.Safari", key: "ShowFullURLInSmartSearchField")
+            },
+            setState: { value in
+                let ok = DefaultsHelper.setBool(value, domain: "com.apple.Safari", key: "ShowFullURLInSmartSearchField")
+                if ok { _ = await TweakExecutor.run("killall Safari") }
+                return ok
+            }
+        )
     ]
 }

--- a/BareMac/BareMac/Services/DefaultsHelper.swift
+++ b/BareMac/BareMac/Services/DefaultsHelper.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+enum DefaultsHelper {
+    static func setBool(_ value: Bool, domain: String, key: String) -> Bool {
+        guard let defaults = UserDefaults(suiteName: domain) else { return false }
+        defaults.set(value, forKey: key)
+        return defaults.synchronize()
+    }
+
+    static func getBool(domain: String, key: String) -> Bool {
+        guard let defaults = UserDefaults(suiteName: domain) else { return false }
+        return defaults.bool(forKey: key)
+    }
+}

--- a/BareMac/BareMac/ViewModels/TweakViewModel.swift
+++ b/BareMac/BareMac/ViewModels/TweakViewModel.swift
@@ -4,7 +4,4 @@ import Foundation
 @MainActor
 final class TweakViewModel: ObservableObject {
     @Published var tweaks = TweaksData.sample
-    func toggle(_ tweak: Tweak) {
-        Task { _ = await TweakExecutor.run(tweak.command) }
-    }
 }

--- a/BareMac/BareMac/Views/ContentView.swift
+++ b/BareMac/BareMac/Views/ContentView.swift
@@ -5,7 +5,7 @@ struct ContentView: View {
     @StateObject private var vm = TweakViewModel()
     var body: some View {
         List(vm.tweaks) { tweak in
-            Button(tweak.name) { vm.toggle(tweak) }
+            TweakRow(tweak: tweak)
         }
         .frame(minWidth: 300, minHeight: 400)
     }

--- a/README.md
+++ b/README.md
@@ -36,23 +36,18 @@ This version (v0.2) focuses entirely on UI/UX polish, modularization, and perfor
 - **Search bar** with live filtering and terminal-style aesthetics
 - Fully **modular SwiftUI file structure**
 - **Graphite-inspired theme** (`#1f1f1e`) and monospaced typography
+- Sample Finder, Dock, Safari, and screenshot tweaks using helper-backed actions
 
-> **Note:** Most tweaks are placeholders or visual mockups.  
-> Core functionality will be expanded in future versions.
+> **Note:** The included tweaks are limited but functional; more categories will be added over time.
 
 ---
 
 ## 🧠 Technical Overview
 
 - SwiftUI-first architecture with MVVM-style separation
-- All toggle commands are handled using:
-  
-  ```swift
-  Process().launchPath = "/bin/zsh"
-  Process().arguments = ["-c", tweak.command]
-  ```
+- Tweaks are applied through a helper that writes directly to `UserDefaults` and restarts affected processes when needed.
 
-- Reversible tweaks (with `revertCommand`) supported
+- Reversible tweaks supported via helper-backed state toggles
 - Toggle changes are instant and stateless (no persistent preferences yet)
 - Built-in `.toastText` system provides lightweight visual feedback
 - Sidebar state and selected category managed with `@State` and `@Binding`
@@ -62,7 +57,7 @@ This version (v0.2) focuses entirely on UI/UX polish, modularization, and perfor
 🔹 ContentView.swift      // Root logic, main layout and toggle logic
 🔹 SidebarView.swift      // Search bar + category sidebar
 🔹 TweakRow.swift         // Individual tweak toggle component
-🔹 TweaksData.swift       // Tweak definitions, commands, categories
+🔹 TweaksData.swift       // Tweak definitions, categories, helper actions
 🔹 IntroView.swift        // Launch screen with transition binding
 ```
 


### PR DESCRIPTION
## Summary
- replace command-based tweaks with async helper actions
- provide a sample set of Finder, Dock, Safari, and screenshot tweaks
- introduce `DefaultsHelper` to write preferences without `defaults`

## Testing
- `swiftc -typecheck BareMac/BareMac/Views/ContentView.swift BareMac/BareMac/Views/TweakRow.swift BareMac/BareMac/Models/Tweak.swift BareMac/BareMac/Models/TweakCategory.swift BareMac/BareMac/Services/TweakExecutor.swift BareMac/BareMac/Services/DefaultsHelper.swift BareMac/BareMac/Models/TweaksData.swift BareMac/BareMac/ViewModels/TweakViewModel.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_6893e0a46eb883289bd52c276f8492b0